### PR TITLE
feat: Add built-in Swagger/OpenAPI 3.0 support with auto-generated docs

### DIFF
--- a/lib/controller/controller-processor.ts
+++ b/lib/controller/controller-processor.ts
@@ -54,6 +54,7 @@ export function processController(
       method,
       url: fullPath,
       handler: routeHandler.bind(target.prototype),
+      originalHandler: routeHandler,
       middlewares,
       hasQueryParams,
       bodyValidator,

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,6 +1,6 @@
 import 'reflect-metadata';
 
-import {createServer, Server} from 'http';
+import {createServer, Server, IncomingMessage, ServerResponse} from 'http';
 import {HttpException} from './exceptions/http.exception';
 
 import {Request} from './interfaces';
@@ -15,8 +15,13 @@ import {MethodDecorator, MethodFactory} from './methods/method-factory';
 import {MiddlewareDecorator, MiddlewareFactory} from './middleware/middleware';
 import {getRegisteredControllers} from './controller/controller-registry';
 import {processController} from './controller/controller-processor';
+import {SwaggerConfig, SwaggerGenerator, generateSwaggerUI} from './swagger';
 
 export {Request, Response, RouteHandler, HttpException};
+
+export interface MuzuServerConfig {
+  swagger?: SwaggerConfig;
+}
 
 export {
   ValidationException,
@@ -31,10 +36,15 @@ export {Get, Post, Put, Delete, Patch} from './methods/method-factory';
 export {Middleware} from './middleware/middleware';
 export {clearRegistry} from './controller/controller-registry';
 
+// Export Swagger/OpenAPI
+export * from './swagger';
+
 export class MuzuServer {
   public readonly server: Server;
   public readonly routeManager: RouteManager;
   public readonly requestHandler: RequestHandler;
+  private swaggerConfig?: SwaggerConfig;
+  private swaggerSpec?: any;
   /**
    * @deprecated Use global Controller decorator instead: `import { Controller } from 'muzu'`
    */
@@ -64,7 +74,7 @@ export class MuzuServer {
    */
   public readonly Patch: MethodDecorator;
 
-  constructor() {
+  constructor(config?: MuzuServerConfig | SwaggerConfig) {
     this.routeManager = new RouteManager();
     const methods = new MethodFactory();
 
@@ -74,15 +84,93 @@ export class MuzuServer {
     const middleware = new MiddlewareFactory();
     this.Middleware = middleware.Middleware;
 
-    this.server = createServer(
-      this.requestHandler.handleRequest.bind(this.requestHandler)
-    );
+    this.server = createServer(this.handleRequest.bind(this));
 
     this.Get = methods.Get;
     this.Post = methods.Post;
     this.Delete = methods.Delete;
     this.Put = methods.Put;
     this.Patch = methods.Patch;
+
+    this.initializeSwagger(config);
+  }
+
+  /**
+   * Initializes Swagger configuration
+   * Supports both old format (direct SwaggerConfig) and new format (MuzuServerConfig)
+   */
+  private initializeSwagger(config?: MuzuServerConfig | SwaggerConfig): void {
+    if (!config) return;
+
+    // Check if it's the new config format (has 'swagger' key)
+    const swaggerConfig = this.isServerConfig(config) ? config.swagger : config;
+
+    if (swaggerConfig && swaggerConfig.enabled !== false) {
+      this.swaggerConfig = swaggerConfig;
+    }
+  }
+
+  private isServerConfig(
+    config: MuzuServerConfig | SwaggerConfig
+  ): config is MuzuServerConfig {
+    return 'swagger' in config;
+  }
+
+  private async handleRequest(
+    req: IncomingMessage,
+    res: ServerResponse
+  ): Promise<void> {
+    // Check and handle Swagger routes
+    if (this.swaggerConfig && req.url) {
+      const swaggerHandled = this.handleSwaggerRoutes(req, res);
+      if (swaggerHandled) return;
+    }
+
+    // Pass to normal request handler
+    return this.requestHandler.handleRequest(req as Request, res as Response);
+  }
+
+  private handleSwaggerRoutes(
+    req: IncomingMessage,
+    res: ServerResponse
+  ): boolean {
+    if (!this.swaggerConfig || !req.url) return false;
+
+    const swaggerPath = this.swaggerConfig.path || '/swagger';
+    const swaggerJsonPath = `${swaggerPath}.json`;
+    const normalizedUrl = this.normalizeSwaggerUrl(req.url);
+
+    // Serve swagger.json
+    if (normalizedUrl === swaggerJsonPath) {
+      this.serveSwaggerJson(res);
+      return true;
+    }
+
+    // Serve swagger UI
+    if (normalizedUrl === swaggerPath) {
+      this.serveSwaggerUI(res, swaggerJsonPath);
+      return true;
+    }
+
+    return false;
+  }
+
+  private normalizeSwaggerUrl(url: string): string {
+    return url.endsWith('/') && url.length > 1 ? url.slice(0, -1) : url;
+  }
+
+  private serveSwaggerJson(res: ServerResponse): void {
+    res.writeHead(200, {'Content-Type': 'application/json'});
+    res.end(JSON.stringify(this.swaggerSpec, null, 2));
+  }
+
+  private serveSwaggerUI(res: ServerResponse, swaggerJsonPath: string): void {
+    const html = generateSwaggerUI(
+      swaggerJsonPath,
+      this.swaggerConfig!.info.title
+    );
+    res.writeHead(200, {'Content-Type': 'text/html'});
+    res.end(html);
   }
 
   private loadControllers(): void {
@@ -92,8 +180,26 @@ export class MuzuServer {
     });
   }
 
+  /**
+   * Generates Swagger/OpenAPI specification
+   */
+  private generateSwagger(): void {
+    if (!this.swaggerConfig) return;
+
+    const generator = new SwaggerGenerator(
+      this.swaggerConfig,
+      this.routeManager
+    );
+    this.swaggerSpec = generator.generate();
+
+    const swaggerPath = this.swaggerConfig.path || '/swagger';
+    console.log(`📚 Swagger UI available at ${swaggerPath}`);
+    console.log(`📄 Swagger JSON available at ${swaggerPath}.json`);
+  }
+
   public listen(port: number, callback?: () => void): void {
     this.loadControllers();
+    this.generateSwagger();
 
     console.log('🚀 Server is listening on port', port);
     this.server.listen(port, callback);

--- a/lib/interfaces/index.ts
+++ b/lib/interfaces/index.ts
@@ -6,6 +6,7 @@ export interface Route {
   method: string;
   url: string;
   handler: RouteHandler;
+  originalHandler?: RouteHandler;
   middlewares?: Function[];
   hasQueryParams?: boolean;
   bodyValidator?: CompiledValidator;

--- a/lib/routing/route-manager.ts
+++ b/lib/routing/route-manager.ts
@@ -1,5 +1,6 @@
 import {Route} from '../interfaces';
 import {RouteTree, SearchResult} from './route-tree';
+import {RouteMetadata} from './route-metadata';
 
 export class RouteManager {
   private trees: Map<string, RouteTree>;
@@ -26,7 +27,8 @@ export class RouteManager {
       route.method,
       route.hasQueryParams,
       route.bodyValidator,
-      route.queryValidator
+      route.queryValidator,
+      route.originalHandler
     );
   }
 
@@ -46,6 +48,34 @@ export class RouteManager {
         });
       });
     });
+    return routes;
+  }
+
+  public getRoutesWithMetadata(): Array<{
+    method: string;
+    path: string;
+    handler: Function;
+    metadata?: RouteMetadata;
+  }> {
+    const routes: Array<{
+      method: string;
+      path: string;
+      handler: Function;
+      metadata?: RouteMetadata;
+    }> = [];
+
+    this.trees.forEach((tree, method) => {
+      const treeRoutes = tree.getAllRoutes();
+      treeRoutes.forEach(({path, handler, metadata}) => {
+        routes.push({
+          method,
+          path,
+          handler,
+          metadata,
+        });
+      });
+    });
+
     return routes;
   }
 

--- a/lib/routing/route-metadata.ts
+++ b/lib/routing/route-metadata.ts
@@ -4,6 +4,7 @@ import {CompiledValidator} from '../validation';
 
 export interface RouteMetadata {
   handler: RouteHandler;
+  originalHandler?: RouteHandler;
 
   composedMiddleware?: ComposedMiddleware;
 

--- a/lib/swagger/decorators.ts
+++ b/lib/swagger/decorators.ts
@@ -1,0 +1,162 @@
+/**
+ * Swagger/OpenAPI decorators for documenting routes
+ */
+
+export interface ApiOperationOptions {
+  summary?: string;
+  description?: string;
+  tags?: string[];
+  operationId?: string;
+}
+
+export interface ApiResponseOptions {
+  status: number;
+  description: string;
+  type?: any;
+  isArray?: boolean;
+}
+
+export interface ApiParameterOptions {
+  name: string;
+  in: 'query' | 'path' | 'header';
+  description?: string;
+  required?: boolean;
+  type?: 'string' | 'number' | 'boolean' | 'integer';
+  example?: any;
+}
+
+export interface ApiBodyOptions {
+  description?: string;
+  required?: boolean;
+  type?: any;
+}
+
+/**
+ * Documents an API operation
+ */
+export function ApiOperation(options: ApiOperationOptions) {
+  return (target: any, propertyKey: string, descriptor: PropertyDescriptor) => {
+    Reflect.defineMetadata('swagger:operation', options, target[propertyKey]);
+    return descriptor;
+  };
+}
+
+/**
+ * Documents an API response
+ */
+export function ApiResponse(options: ApiResponseOptions) {
+  return (target: any, propertyKey: string, descriptor: PropertyDescriptor) => {
+    // Validate status code (silently ignore invalid codes)
+    if (options.status < 100 || options.status > 599) {
+      return descriptor;
+    }
+
+    const existingResponses =
+      Reflect.getMetadata('swagger:responses', target[propertyKey]) || [];
+    existingResponses.push(options);
+    Reflect.defineMetadata(
+      'swagger:responses',
+      existingResponses,
+      target[propertyKey]
+    );
+    return descriptor;
+  };
+}
+
+/**
+ * Documents a query/path/header parameter
+ */
+export function ApiParameter(options: ApiParameterOptions) {
+  return (target: any, propertyKey: string, descriptor: PropertyDescriptor) => {
+    // Validate parameter name (silently ignore invalid names)
+    if (!options.name || options.name.trim().length === 0) {
+      return descriptor;
+    }
+
+    const existingParams =
+      Reflect.getMetadata('swagger:parameters', target[propertyKey]) || [];
+    existingParams.push(options);
+    Reflect.defineMetadata(
+      'swagger:parameters',
+      existingParams,
+      target[propertyKey]
+    );
+    return descriptor;
+  };
+}
+
+/**
+ * Documents request body
+ */
+export function ApiBody(options: ApiBodyOptions) {
+  return (target: any, propertyKey: string, descriptor: PropertyDescriptor) => {
+    Reflect.defineMetadata('swagger:body', options, target[propertyKey]);
+    return descriptor;
+  };
+}
+
+/**
+ * Tag definition with optional description
+ */
+export type TagDefinition = string | {name: string; description?: string};
+
+/**
+ * Tags a controller or operation
+ * Can accept either strings or objects with name and description
+ *
+ * @example
+ * @ApiTags('Users', 'Authentication')
+ * @ApiTags({ name: 'Users', description: 'User management endpoints' })
+ */
+export function ApiTags(...tags: TagDefinition[]) {
+  return (
+    target: any,
+    propertyKey?: string,
+    descriptor?: PropertyDescriptor
+  ) => {
+    if (propertyKey && descriptor) {
+      // Method decorator
+      Reflect.defineMetadata('swagger:tags', tags, target[propertyKey]);
+      return descriptor;
+    } else {
+      // Class decorator
+      Reflect.defineMetadata('swagger:tags', tags, target);
+      return target;
+    }
+  };
+}
+
+/**
+ * Gets API operation metadata
+ */
+export function getApiOperation(target: any): ApiOperationOptions | undefined {
+  return Reflect.getMetadata('swagger:operation', target);
+}
+
+/**
+ * Gets API responses metadata
+ */
+export function getApiResponses(target: any): ApiResponseOptions[] {
+  return Reflect.getMetadata('swagger:responses', target) || [];
+}
+
+/**
+ * Gets API parameters metadata
+ */
+export function getApiParameters(target: any): ApiParameterOptions[] {
+  return Reflect.getMetadata('swagger:parameters', target) || [];
+}
+
+/**
+ * Gets API body metadata
+ */
+export function getApiBody(target: any): ApiBodyOptions | undefined {
+  return Reflect.getMetadata('swagger:body', target);
+}
+
+/**
+ * Gets API tags metadata
+ */
+export function getApiTags(target: any): TagDefinition[] {
+  return Reflect.getMetadata('swagger:tags', target) || [];
+}

--- a/lib/swagger/generator.ts
+++ b/lib/swagger/generator.ts
@@ -1,0 +1,501 @@
+import {RouteManager} from '../routing/route-manager';
+import {getRegisteredControllers} from '../controller/controller-registry';
+import {OpenAPISpec, SwaggerConfig, Operation, Schema} from './types';
+import {
+  getApiOperation,
+  getApiResponses,
+  getApiParameters,
+  getApiBody,
+  getApiTags,
+  TagDefinition,
+} from './decorators';
+import {getValidationRules} from '../validation';
+
+export class SwaggerGenerator {
+  constructor(
+    private config: SwaggerConfig,
+    private routeManager: RouteManager
+  ) {}
+
+  /**
+   * Generates OpenAPI 3.0 specification
+   */
+  public generate(): OpenAPISpec {
+    const spec: OpenAPISpec = {
+      openapi: '3.0.0',
+      info: this.config.info,
+      paths: {},
+    };
+
+    if (this.config.servers) {
+      spec.servers = this.config.servers;
+    }
+
+    try {
+      const controllers = getRegisteredControllers();
+      const routes = this.routeManager.getRoutesWithMetadata();
+
+      for (const route of routes) {
+        const swaggerPath = this.convertPathToSwagger(route.path || '/');
+
+        if (!spec.paths[swaggerPath]) {
+          spec.paths[swaggerPath] = {};
+        }
+
+        const operation = this.buildOperation(route, controllers);
+        const methodLower = route.method.toLowerCase();
+
+        // Safely assign operation to path item
+        const pathItem = spec.paths[swaggerPath];
+        switch (methodLower) {
+          case 'get':
+            pathItem.get = operation;
+            break;
+          case 'post':
+            pathItem.post = operation;
+            break;
+          case 'put':
+            pathItem.put = operation;
+            break;
+          case 'patch':
+            pathItem.patch = operation;
+            break;
+          case 'delete':
+            pathItem.delete = operation;
+            break;
+        }
+      }
+
+      // Collect all unique tags from controllers and routes
+      spec.tags = this.collectTags(controllers, routes);
+    } catch (error) {
+      // Graceful degradation: return partial spec if generation fails
+      if (this.config.debug) {
+        console.warn('[Muzu Swagger] Failed to generate full spec:', error);
+      }
+    }
+
+    return spec;
+  }
+
+  /**
+   * Builds an operation object for a route
+   */
+  private buildOperation(
+    route: {
+      method: string;
+      path: string;
+      handler: Function;
+      metadata?: any;
+    },
+    controllers: any[]
+  ): Operation {
+    const handler = route.metadata?.originalHandler || route.handler;
+
+    const operation: Operation = {
+      responses: {
+        '200': {
+          description: 'Successful response',
+        },
+      },
+    };
+
+    try {
+      // Get swagger metadata from decorators
+      const apiOperation = getApiOperation(handler);
+      const apiResponses = getApiResponses(handler);
+      const apiParameters = getApiParameters(handler);
+      const apiBody = getApiBody(handler);
+
+      // Find controller tags
+      const controllerTags = this.findControllerTags(handler, controllers);
+
+      // Apply operation metadata
+      this.applyOperationMetadata(operation, apiOperation);
+
+      // Apply tags (method-level takes precedence over controller-level)
+      this.applyTags(operation, handler, controllerTags);
+
+      // Apply responses
+      this.applyResponses(operation, apiResponses);
+
+      // Apply parameters
+      this.applyParameters(operation, route.path, apiParameters);
+
+      // Apply request body
+      this.applyRequestBody(operation, apiBody);
+    } catch (error) {
+      // Graceful degradation: return basic operation if metadata extraction fails
+      if (this.config.debug) {
+        console.warn(
+          `[Muzu Swagger] Failed to build operation for ${route.method} ${route.path}:`,
+          error
+        );
+      }
+    }
+
+    return operation;
+  }
+
+  /**
+   * Finds controller tags for a given handler
+   */
+  private findControllerTags(
+    handler: Function,
+    controllers: any[]
+  ): TagDefinition[] {
+    for (const {target} of controllers) {
+      const methods = Object.getOwnPropertyNames(target.prototype);
+      if (methods.some(m => target.prototype[m] === handler)) {
+        return getApiTags(target);
+      }
+    }
+    return [];
+  }
+
+  /**
+   * Applies operation metadata (summary, description, operationId)
+   */
+  private applyOperationMetadata(
+    operation: Operation,
+    apiOperation: any
+  ): void {
+    if (!apiOperation) return;
+
+    if (apiOperation.summary) {
+      operation.summary = apiOperation.summary;
+    }
+    if (apiOperation.description) {
+      operation.description = apiOperation.description;
+    }
+    if (apiOperation.operationId) {
+      operation.operationId = apiOperation.operationId;
+    }
+    if (apiOperation.tags) {
+      operation.tags = apiOperation.tags;
+    }
+  }
+
+  /**
+   * Applies tags to operation (method-level takes precedence)
+   */
+  private applyTags(
+    operation: Operation,
+    handler: Function,
+    controllerTags: TagDefinition[]
+  ): void {
+    const methodTags = getApiTags(handler);
+    if (methodTags.length > 0) {
+      operation.tags = this.normalizeTagsForOperation(methodTags);
+    } else if (controllerTags.length > 0) {
+      operation.tags = this.normalizeTagsForOperation(controllerTags);
+    }
+  }
+
+  /**
+   * Applies response definitions to operation
+   */
+  private applyResponses(operation: Operation, apiResponses: any[]): void {
+    if (apiResponses.length === 0) return;
+
+    operation.responses = {};
+    for (const res of apiResponses) {
+      const statusCode = String(res.status);
+      operation.responses[statusCode] = {
+        description: res.description,
+      };
+
+      if (res.type) {
+        const schema = this.buildSchemaFromType(res.type, res.isArray);
+        operation.responses[statusCode].content = {
+          'application/json': {
+            schema,
+          },
+        };
+      }
+    }
+  }
+
+  /**
+   * Applies parameters (path, query, header) to operation
+   */
+  private applyParameters(
+    operation: Operation,
+    path: string,
+    apiParameters: any[]
+  ): void {
+    const pathParams = this.extractPathParameters(path);
+    if (pathParams.length === 0 && apiParameters.length === 0) return;
+
+    operation.parameters = [];
+
+    // Add path parameters
+    for (const param of pathParams) {
+      const apiParam = apiParameters.find(
+        p => p.name === param && p.in === 'path'
+      );
+      operation.parameters.push({
+        name: param,
+        in: 'path',
+        required: true,
+        description: apiParam?.description,
+        schema: {
+          type: apiParam?.type || 'string',
+        },
+      });
+    }
+
+    // Add other parameters (query, header)
+    for (const param of apiParameters) {
+      if (param.in !== 'path') {
+        operation.parameters.push({
+          name: param.name,
+          in: param.in,
+          required: param.required,
+          description: param.description,
+          schema: {
+            type: param.type || 'string',
+            example: param.example,
+          },
+        });
+      }
+    }
+  }
+
+  /**
+   * Applies request body definition to operation
+   */
+  private applyRequestBody(operation: Operation, apiBody: any): void {
+    if (!apiBody || !apiBody.type) return;
+
+    const schema = this.buildSchemaFromType(apiBody.type);
+    operation.requestBody = {
+      description: apiBody.description,
+      required: apiBody.required !== false,
+      content: {
+        'application/json': {
+          schema,
+        },
+      },
+    };
+  }
+
+  /**
+   * Builds a JSON Schema from a DTO class
+   */
+  private buildSchemaFromType(type: any, isArray = false): Schema {
+    if (!type) {
+      return {type: 'object'};
+    }
+
+    try {
+      const instance = new type();
+      const properties: Record<string, Schema> = {};
+      const required: string[] = [];
+
+      const propertyKeys = Object.getOwnPropertyNames(instance);
+
+      for (const key of propertyKeys) {
+        const rules = getValidationRules(type.prototype, key);
+        const propSchema = this.buildPropertySchema(rules, required, key);
+        properties[key] = propSchema;
+      }
+
+      const schema: Schema = {
+        type: 'object',
+        properties,
+      };
+
+      if (required.length > 0) {
+        schema.required = required;
+      }
+
+      return isArray ? {type: 'array', items: schema} : schema;
+    } catch (error) {
+      // Graceful degradation: return basic schema if DTO instantiation fails
+      if (this.config.debug) {
+        console.warn('[Muzu Swagger] Failed to build schema from type:', error);
+      }
+      return {type: 'object'};
+    }
+  }
+
+  /**
+   * Builds a property schema from validation rules
+   */
+  private buildPropertySchema(
+    rules: any[],
+    required: string[],
+    propertyKey: string
+  ): Schema {
+    const schema: Schema = {type: 'string'};
+
+    for (const rule of rules) {
+      this.applyRuleToSchema(schema, rule, required, propertyKey);
+    }
+
+    return schema;
+  }
+
+  /**
+   * Applies a validation rule to a schema
+   */
+  private applyRuleToSchema(
+    schema: Schema,
+    rule: any,
+    required: string[],
+    propertyKey: string
+  ): void {
+    switch (rule.constraint) {
+      // Type constraints
+      case 'isString':
+        schema.type = 'string';
+        break;
+      case 'isNumber':
+        schema.type = 'number';
+        break;
+      case 'isInt':
+        schema.type = 'integer';
+        break;
+      case 'isBoolean':
+        schema.type = 'boolean';
+        break;
+      case 'isArray':
+        schema.type = 'array';
+        break;
+
+      // Format constraints
+      case 'isEmail':
+        schema.type = 'string';
+        schema.format = 'email';
+        break;
+      case 'isUrl':
+        schema.type = 'string';
+        schema.format = 'uri';
+        break;
+      case 'isUUID':
+        schema.type = 'string';
+        schema.format = 'uuid';
+        break;
+
+      // Numeric constraints
+      case 'min':
+        schema.minimum = rule.value as number;
+        break;
+      case 'max':
+        schema.maximum = rule.value as number;
+        break;
+
+      // String constraints
+      case 'minLength':
+        schema.minLength = rule.value as number;
+        break;
+      case 'maxLength':
+        schema.maxLength = rule.value as number;
+        break;
+      case 'matches':
+        if (rule.value instanceof RegExp) {
+          schema.pattern = rule.value.source;
+        }
+        break;
+
+      // Enum constraint
+      case 'isEnum':
+        if (typeof rule.value === 'object') {
+          schema.enum = Object.values(rule.value);
+        }
+        break;
+
+      // Required constraint
+      case 'isRequired':
+        if (!required.includes(propertyKey)) {
+          required.push(propertyKey);
+        }
+        break;
+    }
+  }
+
+  /**
+   * Collects all unique tags from controllers and routes
+   */
+  private collectTags(
+    controllers: any[],
+    routes: any[]
+  ): Array<{name: string; description?: string}> {
+    const tagMap = new Map<string, {name: string; description?: string}>();
+
+    // Collect tags from controllers
+    for (const {target} of controllers) {
+      const tags = getApiTags(target);
+      for (const tag of tags) {
+        const normalized = this.normalizeTag(tag);
+        if (!tagMap.has(normalized.name)) {
+          tagMap.set(normalized.name, normalized);
+        } else if (normalized.description) {
+          // Update description if new one is provided
+          const existing = tagMap.get(normalized.name)!;
+          existing.description = normalized.description;
+        }
+      }
+    }
+
+    // Collect tags from routes (method-level tags)
+    for (const route of routes) {
+      const handler = route.metadata?.originalHandler || route.handler;
+      const tags = getApiTags(handler);
+      for (const tag of tags) {
+        const normalized = this.normalizeTag(tag);
+        if (!tagMap.has(normalized.name)) {
+          tagMap.set(normalized.name, normalized);
+        } else if (normalized.description) {
+          const existing = tagMap.get(normalized.name)!;
+          existing.description = normalized.description;
+        }
+      }
+    }
+
+    return Array.from(tagMap.values());
+  }
+
+  /**
+   * Normalizes a tag definition to object format
+   */
+  private normalizeTag(tag: TagDefinition): {
+    name: string;
+    description?: string;
+  } {
+    if (typeof tag === 'string') {
+      return {name: tag};
+    }
+    return tag;
+  }
+
+  /**
+   * Normalizes tag definitions to string array for operation
+   */
+  private normalizeTagsForOperation(tags: TagDefinition[]): string[] {
+    return tags.map(tag => (typeof tag === 'string' ? tag : tag.name));
+  }
+
+  /**
+   * Converts Muzu path format to OpenAPI format
+   * Example: /users/:id -> /users/{id}
+   */
+  private convertPathToSwagger(path: string): string {
+    return path.replace(/:([^/]+)/g, '{$1}');
+  }
+
+  /**
+   * Extracts path parameter names from a route
+   * Example: /users/:id/posts/:postId -> ['id', 'postId']
+   */
+  private extractPathParameters(path: string): string[] {
+    const params: string[] = [];
+    const regex = /:([^/]+)/g;
+    let match;
+    while ((match = regex.exec(path)) !== null) {
+      params.push(match[1]);
+    }
+    return params;
+  }
+}

--- a/lib/swagger/index.ts
+++ b/lib/swagger/index.ts
@@ -1,0 +1,4 @@
+export * from './types';
+export * from './decorators';
+export * from './generator';
+export {generateSwaggerUI} from './ui-template';

--- a/lib/swagger/types.ts
+++ b/lib/swagger/types.ts
@@ -1,0 +1,114 @@
+export interface SwaggerConfig {
+  enabled?: boolean;
+  path?: string;
+  debug?: boolean;
+  info: {
+    title: string;
+    version: string;
+    description?: string;
+    contact?: {
+      name?: string;
+      email?: string;
+      url?: string;
+    };
+    license?: {
+      name: string;
+      url?: string;
+    };
+  };
+  servers?: Array<{
+    url: string;
+    description?: string;
+  }>;
+}
+
+export interface OpenAPISpec {
+  openapi: string;
+  info: {
+    title: string;
+    version: string;
+    description?: string;
+    contact?: {
+      name?: string;
+      email?: string;
+      url?: string;
+    };
+    license?: {
+      name: string;
+      url?: string;
+    };
+  };
+  servers?: Array<{
+    url: string;
+    description?: string;
+  }>;
+  tags?: Array<{
+    name: string;
+    description?: string;
+  }>;
+  paths: Record<string, PathItem>;
+  components?: {
+    schemas?: Record<string, Schema>;
+    responses?: Record<string, Response>;
+  };
+}
+
+export interface PathItem {
+  get?: Operation;
+  post?: Operation;
+  put?: Operation;
+  patch?: Operation;
+  delete?: Operation;
+  parameters?: Parameter[];
+}
+
+export interface Operation {
+  summary?: string;
+  description?: string;
+  operationId?: string;
+  tags?: string[];
+  parameters?: Parameter[];
+  requestBody?: RequestBody;
+  responses: Record<string, Response>;
+}
+
+export interface Parameter {
+  name: string;
+  in: 'query' | 'path' | 'header' | 'cookie';
+  description?: string;
+  required?: boolean;
+  schema: Schema;
+}
+
+export interface RequestBody {
+  description?: string;
+  required?: boolean;
+  content: Record<string, MediaType>;
+}
+
+export interface MediaType {
+  schema: Schema;
+}
+
+export interface Response {
+  description: string;
+  content?: Record<string, MediaType>;
+}
+
+export interface Schema {
+  type?: string;
+  format?: string;
+  description?: string;
+  required?: string[];
+  properties?: Record<string, Schema>;
+  items?: Schema;
+  enum?: any[];
+  example?: any;
+  default?: any;
+  minimum?: number;
+  maximum?: number;
+  minLength?: number;
+  maxLength?: number;
+  pattern?: string;
+  $ref?: string;
+}

--- a/lib/swagger/ui-template.ts
+++ b/lib/swagger/ui-template.ts
@@ -1,0 +1,79 @@
+export function generateSwaggerUI(
+  swaggerJsonPath: string,
+  title: string
+): string {
+  return `
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>${title} - Swagger UI</title>
+  <link rel="stylesheet" href="https://unpkg.com/swagger-ui-dist@5.19.0/swagger-ui.css">
+  <style>
+    body {
+      margin: 0;
+      padding: 0;
+    }
+    .topbar {
+      display: none;
+    }
+    .muzu-footer {
+      position: fixed;
+      bottom: 0;
+      right: 0;
+      padding: 8px 16px;
+      font-size: 12px;
+      color: #666;
+      background: rgba(255, 255, 255, 0.9);
+      border-top-left-radius: 4px;
+      box-shadow: 0 -1px 3px rgba(0,0,0,0.1);
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+      z-index: 9999;
+    }
+    .muzu-footer a {
+      color: #3b82f6;
+      text-decoration: none;
+      font-weight: 500;
+    }
+    .muzu-footer a:hover {
+      text-decoration: underline;
+    }
+    .muzu-footer .note-emoji {
+      display: inline-block;
+      animation: bounce 2s infinite;
+    }
+    @keyframes bounce {
+      0%, 100% { transform: translateY(0); }
+      50% { transform: translateY(-3px); }
+    }
+  </style>
+</head>
+<body>
+  <div id="swagger-ui"></div>
+  <div class="muzu-footer">
+    Made with <span class="note-emoji">❤️</span> using <a href="https://muzu.dev" target="_blank">Muzu</a>
+  </div>
+  <script src="https://unpkg.com/swagger-ui-dist@5.19.0/swagger-ui-bundle.js"></script>
+  <script src="https://unpkg.com/swagger-ui-dist@5.19.0/swagger-ui-standalone-preset.js"></script>
+  <script>
+    window.onload = function() {
+      window.ui = SwaggerUIBundle({
+        url: '${swaggerJsonPath}',
+        dom_id: '#swagger-ui',
+        deepLinking: true,
+        presets: [
+          SwaggerUIBundle.presets.apis,
+          SwaggerUIStandalonePreset
+        ],
+        plugins: [
+          SwaggerUIBundle.plugins.DownloadUrl
+        ],
+        layout: "StandaloneLayout"
+      });
+    };
+  </script>
+</body>
+</html>
+  `.trim();
+}


### PR DESCRIPTION
- Integrate Swagger UI and JSON spec generation directly into MuzuServer
- Support OpenAPI decorators (@ApiTags, @ApiOperation, @ApiResponse, @ApiParameter, @ApiBody)
- Auto-generate API documentation from route and validation metadata
- Serve interactive Swagger UI at configurable path (default: /swagger)
- Preserve original handler references for accurate metadata extraction
- Add comprehensive README section explaining usage and examples
- Improve route manager to expose metadata needed for documentation
- Add graceful error handling and debug mode for Swagger generation
- Update Swagger UI to latest version and customize UI footer
- Add validation guards for decorator parameters to prevent invalid configs

This makes Muzu a fully self-documenting backend framework with zero external dependencies.